### PR TITLE
Allow simulators other than GHDL and ModelSim in run.py

### DIFF
--- a/sim/run.py
+++ b/sim/run.py
@@ -18,10 +18,11 @@ if "--coverage" in sys.argv:
         "Coverage is only allowed with --modelsim"
 
 # Obviously the simulator must be chosen before sources are added
-if USE_GHDL:
-    os.environ['VUNIT_SIMULATOR'] = 'ghdl'
-else:
-    os.environ['VUNIT_SIMULATOR'] = 'modelsim'
+if 'VUNIT_SIMULATOR' not in os.environ:
+    if USE_GHDL:
+        os.environ['VUNIT_SIMULATOR'] = 'ghdl'
+    else:
+        os.environ['VUNIT_SIMULATOR'] = 'modelsim'
 
 # Parse VUnit Arguments
 vu = VUnit.from_argv(compile_builtins=False, argv=argv)
@@ -46,8 +47,8 @@ files = glob('../test/**/*.vhd', recursive=True)
 olo_tb.add_source_files(files)
 
 # Obviously flags must be set after files are imported
-if USE_GHDL:
-    vu.add_compile_option('ghdl.a_flags', ['-frelaxed-rules', '-Wno-hide', '-Wno-shared'])
+vu.add_compile_option('ghdl.a_flags', ['-frelaxed-rules', '-Wno-hide', '-Wno-shared'])
+vu.add_compile_option('nvc.a_flags', ['--relaxed'])
 
 ########################################################################################################################
 # Shared Functions
@@ -339,8 +340,8 @@ for LsbFirst in [False, True]:
 ########################################################################################################################
 # Execution
 ########################################################################################################################
-if USE_GHDL:
-    olo_tb.set_sim_option('ghdl.elab_flags', ['-frelaxed'])
+
+olo_tb.set_sim_option('ghdl.elab_flags', ['-frelaxed'])
 
 if USE_COVERAGE:
     olo.set_compile_option('modelsim.vcom_flags', ['+cover=bs'])


### PR DESCRIPTION
If the `VUNIT_SIMULATOR` environment variable is already set then use that instead of overriding it.  This allows the regression tests to run with the VHDL simulator I am developing at [nickg/nvc](https://github.com/nickg/nvc).

As far as I know it's fine to set simulator-specific VUnit options (e.g. `ghdl.elab_flags`) when that simulator is not selected.