### PR TITLE
ENHANCEMENT: Add support of longer output symbols to olo_base_prbs

### DIFF
--- a/doc/EntityList.md
+++ b/doc/EntityList.md
@@ -88,7 +88,7 @@ See [Conventions](./Conventions.md) for a description about TDM (time-division-m
 | [olo_base_delay](./base/olo_base_delay.md)                   | Fixed duration delay (fixed number of data-beats)            |
 | [olo_base_delay_cfg](./base/olo_base_delay_cfg.md)           | Configurable duration delay (runtime configurable number of data-beats) |
 | [olo_base_dyn_sft](./base/olo_base_dyn_sft.md)               | Dynamic barrel shifter (number of bits to shift is configurable per sample at runtime) |
-| [olo_base_prbs](./base/olo_base_brbs.md)                     | PRBS (pseudo random binary sequence) generator based on linear feedback shift register (LFSR) implementation. |
+| [olo_base_prbs](./base/olo_base_prbs.md)                     | PRBS (pseudo random binary sequence) generator based on linear feedback shift register (LFSR) implementation. |
 | [olo_base_strobe_gen](./base/olo_base_strobe_gen.md)         | Strobe generator. Generate pulses at a fixed frequency       |
 | [olo_base_strobe_div](./base/olo_base_strobe_div.md)         | Strobe divider. Only forward every N'th pulse (divide event frequency). <br />Can also be used to convert single-cycle pulses to acknowledged events (pulse stays active until acknowledged). |
 | [olo_base_reset_gen](./base/olo_base_reset_gen.md)           | Reset generator - Generates reset pulses of specified duration after configuration and upon request |

--- a/doc/base/olo_base_prbs.md
+++ b/doc/base/olo_base_prbs.md
@@ -16,9 +16,9 @@ VHDL Source: [olo_base_prbs](../../src/base/vhdl/olo_base_prbs.vhd)
 
 This component generates a pseudorandom binary sequence based (PRBS) on a logic feed-back shift register (LFSR) method.
 A set of common polynomials (aiming the maximum cycle possible) is available in
-[olo_base_pkg_logic](./olo_base_pkg_logic.md) and can be passed to _olo_base_prbs_ through the generic _Polynomical_g_.
+[olo_base_pkg_logic](./olo_base_pkg_logic.md) and can be passed to _olo_base_prbs_ through the generic _Polynomial_g_.
 
-The number of bits per symbol which is presented at the output is configurable (up to the width of the LFSR).
+The number of bits per symbol which is presented at the output is configurable.
 
 Polynomials are passed as _std_logic_vector_ where a one denotes every position where x^n is used: "100010000" means
 "x⁹ +x⁵ + 1".
@@ -31,10 +31,9 @@ will stay zero forever.
 
 | Name            | Type             | Default | Description                                                  |
 | :-------------- | :--------------- | ------- | :----------------------------------------------------------- |
-| LfsrWidth_g     | positive         | -       | Width of the LFSR in bits (must be >= 2)                     |
-| Polynomial_g    | std_logic_vector | -       | Polynomial to use. Width according to _LfsrWidth_g_.<br />"100010000" means "x⁴+x⁸". |
-| Seed_g          | std_logic_vector | -       | Initial state of the LFSR. Width according to _LfsrWidth_g_. Must be non-zero. |
-| BitsPerSymbol_g | positive         | 1       | Number of bits of the PRBS sequence to present at the output for every symbol (width of _Out_Data_). <br />Must be smaller or equal to _LfsrWidth_g_. |
+| Polynomial_g    | std_logic_vector | -       | Polynomial to use. <br />"100010000" means "x⁴+x⁸". |
+| Seed_g          | std_logic_vector | -       | Initial state of the LFSR. Needs to be the same width as _Polynomial_g_. Must be non-zero vector. |
+| BitsPerSymbol_g | positive         | 1       | Number of bits of the PRBS sequence to present at the output for every symbol (width of _Out_Data_). <br />Must be at least 1. |
 
 ## Interfaces
 

--- a/src/base/vhdl/olo_base_prbs.vhd
+++ b/src/base/vhdl/olo_base_prbs.vhd
@@ -27,13 +27,13 @@ library ieee;
 
 library work;
     use work.olo_base_pkg_logic.all;
+    use work.olo_base_pkg_math.all;
 
 ---------------------------------------------------------------------------------------------------
 -- Entity
 ---------------------------------------------------------------------------------------------------
 entity olo_base_prbs is
     generic (
-        LfsrWidth_g     : positive range 2 to natural'high;
         Polynomial_g    : std_logic_vector;
         Seed_g          : std_logic_vector;
         BitsPerSymbol_g : positive := 1
@@ -44,12 +44,12 @@ entity olo_base_prbs is
         Rst              : in    std_logic;
         -- Output
         Out_Data         : out   std_logic_vector(BitsPerSymbol_g-1 downto 0);
-        Out_Ready        : in    std_logic                                := '1';
+        Out_Ready        : in    std_logic                                        := '1';
         Out_Valid        : out   std_logic;
         -- State
-        State_Current    : out   std_logic_vector(LfsrWidth_g-1 downto 0);
-        State_New        : in    std_logic_vector(LfsrWidth_g-1 downto 0) := (others => '0');
-        State_Set        : in    std_logic                                := '0'
+        State_Current    : out   std_logic_vector(Polynomial_g'length-1 downto 0);
+        State_New        : in    std_logic_vector(Polynomial_g'length-1 downto 0) := (others => '0');
+        State_Set        : in    std_logic                                        := '0'
     );
 end entity;
 
@@ -59,32 +59,42 @@ end entity;
 
 architecture rtl of olo_base_prbs is
 
+    -- Functions
+    function lfsrRegLength (constant PL_c : natural; constant BPS_c : natural) return natural is
+    begin
+        if BPS_c > PL_c then
+            return BPS_c;
+        else
+            return PL_c;
+        end if;
+    end function;
+
     -- Signals
-    signal LfsrReg : std_logic_vector(LfsrWidth_g-1 downto 0);
+    signal LfsrReg : std_logic_vector(lfsrRegLength(Polynomial_g'length, BitsPerSymbol_g)-1 downto 0);
 
 begin
 
-    assert Polynomial_g'length = LfsrWidth_g
-        report "###ERROR###: olo_base_prbs - Polynomial_g width must match LfsrWidth_g"
+    assert Polynomial_g'length >= 2
+        report "###ERROR###: olo_base_prbs - Polynomial_g width must be at least 2"
         severity error;
-    assert Seed_g'length = LfsrWidth_g
-        report "###ERROR###: olo_base_prbs - Seed_g width must match LfsrWidth_g"
+    assert Seed_g'length = Polynomial_g'length
+        report "###ERROR###: olo_base_prbs - Seed_g width must match Polynomial_g width"
         severity error;
-    assert unsigned(Seed_g) /= 0
+    assert fromUslv(Seed_g) /= 0
         report "###ERROR###: olo_base_prbs - Seed_g MUST NOT be zero"
         severity error;
-    assert BitsPerSymbol_g <= LfsrWidth_g
-        report "###ERROR###: olo_base_prbs - BitsPerSymbol_g width must  be smaller or equal to LfsrWidth_g"
+    assert BitsPerSymbol_g >= 1
+        report "###ERROR###: olo_base_prbs - BitsPerSymbol_g width must be larger or equal to 1"
         severity error;
 
     Out_Valid     <= '1';
     Out_Data      <= invertBitOrder(LfsrReg(LfsrReg'high downto LfsrReg'length-BitsPerSymbol_g));
-    State_Current <= LfsrReg;
+    State_Current <= LfsrReg(State_Current'high downto 0);
 
     p_lfsr : process (Clk) is
         variable NextBit_v    : std_logic;
         variable Lfsr_v       : std_logic_vector(LfsrReg'range);
-        variable LfsrMasked_v : std_logic_vector(LfsrReg'range);
+        variable LfsrMasked_v : std_logic_vector(Polynomial_g'length-1 downto 0);
     begin
         if rising_edge(Clk) then
             -- Normal Operation
@@ -93,9 +103,9 @@ begin
 
                 -- Loop over all bits in symbol
                 for bit in 0 to BitsPerSymbol_g-1 loop
-                    LfsrMasked_v := Lfsr_v and Polynomial_g;
+                    LfsrMasked_v := Lfsr_v(Polynomial_g'length-1 downto 0) and Polynomial_g;
                     NextBit_v    := xor_reduce(LfsrMasked_v);
-                    Lfsr_v       := Lfsr_v(LfsrWidth_g-2 downto 0) & NextBit_v;
+                    Lfsr_v       := Lfsr_v(Lfsr_v'high-1 downto 0) & NextBit_v;
                 end loop;
 
                 LfsrReg <= Lfsr_v;
@@ -103,15 +113,18 @@ begin
 
             -- Load state
             if State_Set = '1' then
-                LfsrReg <= State_New;
+                LfsrReg                                 <= (others => '0');
+                LfsrReg(Polynomial_g'length-1 downto 0) <= State_New;
             end if;
 
             -- Reset
             if Rst = '1' then
-                LfsrReg <= Seed_g;
+                LfsrReg                                 <= (others => '0');
+                LfsrReg(Polynomial_g'length-1 downto 0) <= Seed_g;
             end if;
 
         end if;
+
     end process;
 
 end architecture;

--- a/test/base/olo_base_prbs/olo_base_prbs4_tb.vhd
+++ b/test/base/olo_base_prbs/olo_base_prbs4_tb.vhd
@@ -162,7 +162,6 @@ begin
     -----------------------------------------------------------------------------------------------
     i_dut : entity olo.olo_base_prbs
         generic map (
-            LfsrWidth_g     => 4,
             Polynomial_g    => Polynomial_Prbs4_c,
             Seed_g          => "1111",
             BitsPerSymbol_g => BitsPerSymbol_g


### PR DESCRIPTION
Add the necessary changes to olo_base_prbs.vhd
	- determine length of output in relation to lfsr
	- adapt output generation
	- remove redundant interface input (PolynomWidth_g = Polynomial'length)

Change documentation accordingly
	- update olo_base_prbs.md
	- fix link to olo_base_prbs.md in EntityList.md

Change olo_base_prbs_tb.vhd to new interface