### PR TITLE
NONCOMPATIBLE CHANGE: For olo_fix_round/saturate do round and saturate by default

### DIFF
--- a/doc/fix/olo_fix_round.md
+++ b/doc/fix/olo_fix_round.md
@@ -35,13 +35,13 @@ For details about the fixed-point number format used in _Open Logic_, refer to t
 
 ## Generics
 
-| Name        | Type    | Default   | Description                                                  |
-| :---------- | :------ | --------- | :----------------------------------------------------------- |
-| AFmt_g      | string  | -         | Input A format<br />String representation of an _en_cl_fix Format_t_ (e.g. "(1,1,15)") |
-| ResultFmt_g | string  | -         | Format of the result<br />String representation of an _en_cl_fix Format_t_ (e.g. "(0,1,15)") |
-| Round_g     | string  | "Trunc_s" | Rounding mode<br />String representation of an _en_cl_fix FixRound_t_. |
-| FmtCheck_g  | boolean | true      | If true, an error is thrown in case _ResultFmt_g_ is not as required |
-| RoundReg_g  | string  | "YES"     | Presence of rounding pipeline stage<br />"YES": Always implement register<br />"NO": Never implement register<br />"AUTO": Implement register if rounding is needed according to the formats chosen |
+| Name        | Type    | Default       | Description                                                  |
+| :---------- | :------ | ------------- | :----------------------------------------------------------- |
+| AFmt_g      | string  | -             | Input A format<br />String representation of an _en_cl_fix Format_t_ (e.g. "(1,1,15)") |
+| ResultFmt_g | string  | -             | Format of the result<br />String representation of an _en_cl_fix Format_t_ (e.g. "(0,1,15)") |
+| Round_g     | string  | "NonSymPos_s" | Rounding mode<br />String representation of an _en_cl_fix FixRound_t_. |
+| FmtCheck_g  | boolean | true          | If true, an error is thrown in case _ResultFmt_g_ is not as required |
+| RoundReg_g  | string  | "YES"         | Presence of rounding pipeline stage<br />"YES": Always implement register<br />"NO": Never implement register<br />"AUTO": Implement register if rounding is needed according to the formats chosen |
 
 ## Interfaces
 

--- a/src/fix/python/olo_fix/olo_fix_round.py
+++ b/src/fix/python/olo_fix/olo_fix_round.py
@@ -23,7 +23,7 @@ class olo_fix_round:
     def __init__(self,
                  a_fmt : FixFormat,
                  result_fmt : FixFormat,
-                 round : FixRound = FixRound.Trunc_s):
+                 round : FixRound = FixRound.NonSymPos_s):
         """
         Constructor for the olo_fix_round class.
         :param a_fmt: Format of the a input

--- a/src/fix/python/olo_fix/olo_fix_saturate.py
+++ b/src/fix/python/olo_fix/olo_fix_saturate.py
@@ -23,7 +23,7 @@ class olo_fix_saturate:
     def __init__(self,
                  a_fmt : FixFormat,
                  result_fmt : FixFormat,
-                 saturate : FixSaturate = FixSaturate.Warn_s):
+                 saturate : FixSaturate = FixSaturate.Sat_s):
         """
         Constructor for the olo_fix_resize class.
         :param a_fmt: Format of the a input

--- a/src/fix/vhdl/olo_fix_round.vhd
+++ b/src/fix/vhdl/olo_fix_round.vhd
@@ -37,7 +37,7 @@ entity olo_fix_round is
         -- Formats / Round / Saturate
         AFmt_g      : string;
         ResultFmt_g : string;
-        Round_g     : string  := FixRound_Trunc_c;
+        Round_g     : string  := FixRound_NonSymPos_c;
         FmtCheck_g  : boolean := true;
         -- Registers
         RoundReg_g  : string  := "YES"

--- a/src/fix/vhdl/olo_fix_saturate.vhd
+++ b/src/fix/vhdl/olo_fix_saturate.vhd
@@ -37,7 +37,7 @@ entity olo_fix_saturate is
         -- Formats / Round / Saturate
         AFmt_g      : string;
         ResultFmt_g : string;
-        Saturate_g  : string := FixSaturate_Warn_c;
+        Saturate_g  : string := FixSaturate_Sat_c;
         -- Registers
         SatReg_g    : string := "YES"
     );


### PR DESCRIPTION
Thos entities would not be used if the idea is not to execute the rounding/saturation. So this is the better default.