### PR TITLE
DOC: Fixed various small typos

### DIFF
--- a/doc/base/olo_base_arb_prio.md
+++ b/doc/base/olo_base_arb_prio.md
@@ -19,7 +19,7 @@ granted (i.e. asserted in the grant  vector). The arbiter is implemented using t
 parallel prefix computation approach.
 
 The arbiter can be implemented with or without an output registers. The waveform below shows its implementation with
-andwithout output register (_Latency\_g = 0_ resp. 1).
+and without output register (_Latency\_g = 0_ resp. 1).
 
 ![Waveform](./arb/olo_base_arb_prio_example.png)
 

--- a/doc/base/olo_base_arb_rr.md
+++ b/doc/base/olo_base_arb_rr.md
@@ -57,8 +57,8 @@ section of the waveform.
 | Name      | In/Out | Length    | Default | Description                                                  |
 | :-------- | :----- | :-------- | ------- | :----------------------------------------------------------- |
 | Out_Grant | out    | _Width_g_ | N/A     | Grant output signal                                          |
-| Out_Ready | out    | 1         | N/A     | AXI-S handshaking signal, Asserted whenever Grant != 0       |
-| Out_Valid | out    | 1         | N/A     | AXI-S handshaking signal The state of the  arbiter is updated  upon _Out\_Ready = '1'_ |
+| Out_Ready | in     | 1         | N/A     | AXI-S handshaking signal                                     |
+| Out_Valid | out    | 1         | N/A     | AXI-S handshaking signal, Asserted whenever Grant != 0. The state of the  arbiter is updated  upon _Out\_Ready = '1'_ |
 
 Note that the output is not fully AXI4-Stream compliant because the _Out_Grant_ vector can change its value while
 _Out_Valid_ is asserted (as shown in the example waveform further up). Still the naming of the signals was kept because

--- a/doc/base/olo_base_ram_sp.md
+++ b/doc/base/olo_base_ram_sp.md
@@ -53,7 +53,7 @@ Below figure explains the _RdLatency_g_ generic in detail:
 ### Byte Enables
 
 Due to tool limitations regarding inference, the usage of byte enables (_UseByteEnable_g=true_) can lead to increased
-RAM usage.nTherefore, **do not use byte enable signals unless this is strictly required**.
+RAM usage. Therefore, **do not use byte enable signals unless this is strictly required**.
 
 Open Logic internally does not use byte enables, hence only users using the _olo_base_ram_sp_ component directly with
 byte-enables enabled are affected.

--- a/test/base/olo_base_arb_prio/olo_base_arb_prio_tb.vhd
+++ b/test/base/olo_base_arb_prio/olo_base_arb_prio_tb.vhd
@@ -49,7 +49,7 @@ architecture sim of olo_base_arb_prio_tb is
     signal Out_Grant : std_logic_vector(Width_c - 1 downto 0) := (others => '0');
 
     -----------------------------------------------------------------------------------------------
-    -- TB Defnitions
+    -- TB Definitions
     -----------------------------------------------------------------------------------------------
     constant Clk_Frequency_c : real    := 100.0e6;
     constant Clk_Period_c    : time    := (1 sec) / Clk_Frequency_c;


### PR DESCRIPTION
Various small typo fixes.

@obruendl, please review changes in `olo_base_arb_rr.md`. 