### PR TITLE
CLEANUP: Enable Libero RD build after issue in pipeline was fixed

### DIFF
--- a/.github/workflows/rd_build.yml
+++ b/.github/workflows/rd_build.yml
@@ -105,13 +105,11 @@ jobs:
           gw_sh scripted_build_sv_sh.tcl
       # Libero
       - name: Libero VHDL
-        if: false #Libero currently fails on AWS - issue under innvestigation. RD build is checked manually.
         run: |
           source $LOCAL_TOOLS
           cd ./doc/tutorials/LiberoTutorial/Files
           libero script:scripted_build.tcl
       - name: Libero Verilog
-        if: false #Libero currently fails on AWS - issue under innvestigation. RD build is checked manually.
         run: |
           source $LOCAL_TOOLS
           cd ./doc/tutorials/LiberoTutorial/Files


### PR DESCRIPTION
Libero Bitgen needs 16GB of memory. This was fixed by using a T3.xlarge instance (instead of T3.large)