### PR TITLE
Add scoped constraint for olo_base_ram_sdp.tcl

### DIFF
--- a/.github/workflows/rd_build.yml
+++ b/.github/workflows/rd_build.yml
@@ -105,13 +105,11 @@ jobs:
           gw_sh scripted_build_sv_sh.tcl
       # Libero
       - name: Libero VHDL
-        if: false #Libero currently fails on AWS - issue under innvestigation. RD build is checked manually.
         run: |
           source $LOCAL_TOOLS
           cd ./doc/tutorials/LiberoTutorial/Files
           libero script:scripted_build.tcl
       - name: Libero Verilog
-        if: false #Libero currently fails on AWS - issue under innvestigation. RD build is checked manually.
         run: |
           source $LOCAL_TOOLS
           cd ./doc/tutorials/LiberoTutorial/Files

--- a/src/base/olo_base_dev.core
+++ b/src/base/olo_base_dev.core
@@ -50,6 +50,7 @@ filesets:
     files:
       - "tcl/olo_base_cc_simple.tcl" : {copyto: "base/olo_base_cc_simple.tcl"}
       - "tcl/olo_base_reset_gen.tcl" : {copyto: "base/olo_base_reset_gen.tcl"}
+      - "tcl/olo_base_ram_sdp.tcl" : {copyto: "base/olo_base_ram_sdp.tcl"}
       - "tcl/olo_base_cc_reset.tcl" : {copyto: "base/olo_base_cc_reset.tcl"}
       - "tcl/olo_base_cc_bits.tcl" : {copyto: "base/olo_base_cc_bits.tcl"}
       - "tcl/olo_base_constraints_amd.tcl"  : {copyto: "base/olo_base_constraints_amd.tcl", file_type: "tclSource"}

--- a/src/base/tcl/olo_base_constraints_amd.tcl
+++ b/src/base/tcl/olo_base_constraints_amd.tcl
@@ -9,7 +9,7 @@ namespace eval olo_base_constraints_amd {
 	read_xdc -quiet -ref olo_base_cc_bits $fileLoc/olo_base_cc_bits.tcl
 	read_xdc -quiet -ref olo_base_cc_simple $fileLoc/olo_base_cc_simple.tcl
 	read_xdc -quiet -ref olo_base_reset_gen $fileLoc/olo_base_reset_gen.tcl
-	read_xdc -quiet -ref olo_base_ram_sdp $fileLoc/olo_base_ram_sdp.tcl
+	read_xdc -quiet -ref olo_base_ram_sdp $fileLoc/olo_base_ram_sdp.tcl -unmanaged
 
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_cc_reset.tcl]
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_cc_bits.tcl]

--- a/src/base/tcl/olo_base_constraints_amd.tcl
+++ b/src/base/tcl/olo_base_constraints_amd.tcl
@@ -5,10 +5,10 @@ namespace eval olo_base_constraints_amd {
 
 	puts "OLO LOAD read_xdc for base"
 
-	read_xdc -quiet -ref olo_base_cc_reset $fileLoc/olo_base_cc_reset.tcl
-	read_xdc -quiet -ref olo_base_cc_bits $fileLoc/olo_base_cc_bits.tcl
-	read_xdc -quiet -ref olo_base_cc_simple $fileLoc/olo_base_cc_simple.tcl
-	read_xdc -quiet -ref olo_base_reset_gen $fileLoc/olo_base_reset_gen.tcl
+	read_xdc -quiet -ref olo_base_cc_reset $fileLoc/olo_base_cc_reset.tcl -unmanaged
+	read_xdc -quiet -ref olo_base_cc_bits $fileLoc/olo_base_cc_bits.tcl -unmanaged
+	read_xdc -quiet -ref olo_base_cc_simple $fileLoc/olo_base_cc_simple.tcl -unmanaged
+	read_xdc -quiet -ref olo_base_reset_gen $fileLoc/olo_base_reset_gen.tcl -unmanaged
 	read_xdc -quiet -ref olo_base_ram_sdp $fileLoc/olo_base_ram_sdp.tcl -unmanaged
 
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_cc_reset.tcl]

--- a/src/base/tcl/olo_base_constraints_amd.tcl
+++ b/src/base/tcl/olo_base_constraints_amd.tcl
@@ -9,16 +9,19 @@ namespace eval olo_base_constraints_amd {
 	read_xdc -quiet -ref olo_base_cc_bits $fileLoc/olo_base_cc_bits.tcl
 	read_xdc -quiet -ref olo_base_cc_simple $fileLoc/olo_base_cc_simple.tcl
 	read_xdc -quiet -ref olo_base_reset_gen $fileLoc/olo_base_reset_gen.tcl
+	read_xdc -quiet -ref olo_base_ram_sdp $fileLoc/olo_base_ram_sdp.tcl
 
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_cc_reset.tcl]
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_cc_bits.tcl]
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_cc_simple.tcl]
 	set_property used_in_synthesis false [get_files $fileLoc/olo_base_reset_gen.tcl]
+	set_property used_in_synthesis false [get_files $fileLoc/olo_base_ram_sdp.tcl]
 
 	set_property PROCESSING_ORDER LATE [get_files $fileLoc/olo_base_cc_reset.tcl]
 	set_property PROCESSING_ORDER LATE [get_files $fileLoc/olo_base_cc_bits.tcl]
 	set_property PROCESSING_ORDER LATE [get_files $fileLoc/olo_base_cc_simple.tcl]
 	set_property PROCESSING_ORDER LATE [get_files $fileLoc/olo_base_reset_gen.tcl]
+	set_property PROCESSING_ORDER LATE [get_files $fileLoc/olo_base_ram_sdp.tcl]
 
 	set_msg_config -id {Designutils 20-1281} -new_severity WARNING
 }

--- a/src/base/tcl/olo_base_ram_sdp.tcl
+++ b/src/base/tcl/olo_base_ram_sdp.tcl
@@ -7,7 +7,12 @@
 # Scoped constraints for olo_base_ram_sdp
 # Load in Vivado using "read_xdc -ref olo_base_ram_sdp <path>/olo_base_ram_sdp.tcl"
 
-# These constraints are only necessary when the RAM is implemented as LUTRAM
+# These constraints are only necessary when the RAM is implemented as LUTRAM.
+# In this case there is a timing path from the write clock to the first read data register.
+# See https://docs.amd.com/r/en-US/ug906-vivado-design-analysis/LUTRAM-Read/Write-Potential-Collision.
+# This path can be safely ignored in order for timing to pass because the logic of the async FIFO
+# can never generate the same read and write addresses during active read and write operations.
+# This is not needed for BRAM since the first read data register is located in the BRAM primitive.
 set ram_type [expr {[regexp {LUTRAM} [get_property PRIMITIVE_SUBGROUP [get_cells -hierarchical g_async.Mem_v*]]] ? "LUTRAM" : ""}]
 
 if {$ram_type eq "LUTRAM"} {
@@ -17,4 +22,10 @@ if {$ram_type eq "LUTRAM"} {
     set period [get_property -min PERIOD [get_clocks "$launch_clk $latch_clk"]]
 
     set_max_delay -from $launch_clk -to [get_cell -hierarchical g_async.RdPipe_reg[1][*]] -datapath_only $period
+
+    # Waive "LUTRAM read/write potential collision" CDC warning from "report_cdc" command.
+    create_waiver -type CDC -id "CDC-26" \
+      -from [get_pins *.i_ram/g_async.Mem_v*/*/CLK] \
+      -to [get_pins *.i_ram/g_async.RdPipe_reg[1][*]/D] \
+      -description "Read/Write logic (like for Async FIFO) should ensure no collision"
 }

--- a/src/base/tcl/olo_base_ram_sdp.tcl
+++ b/src/base/tcl/olo_base_ram_sdp.tcl
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------
+#-  Copyright (c) 2025 by Oliver Bründler
+#-  All rights reserved.
+#-  Oliver Bründler
+#-----------------------------------------------------------------------------
+
+# Scoped constraints for olo_base_ram_sdp
+# Load in Vivado using "read_xdc -ref olo_base_ram_sdp <path>/olo_base_ram_sdp.tcl"
+
+# These constraints are only necessary when the RAM is implemented as LUTRAM
+set ram_type [expr {[regexp {LUTRAM} [get_property PRIMITIVE_SUBGROUP [get_cells -hierarchical g_async.Mem_v*]]] ? "LUTRAM" : ""}]
+
+if {$ram_type eq "LUTRAM"} {
+    set launch_clk [get_clocks -of_objects [get_cell -hierarchical g_async.Mem_v*]]
+    set latch_clk [get_clocks -of_objects [get_cell -hierarchical g_async.RdPipe_reg[1][*]]]
+
+    set period [get_property -min PERIOD [get_clocks "$launch_clk $latch_clk"]]
+
+    set_max_delay -from $launch_clk -to [get_cell -hierarchical g_async.RdPipe_reg[1][*]] -datapath_only $period
+}

--- a/src/base/vhdl/olo_base_ram_sdp.vhd
+++ b/src/base/vhdl/olo_base_ram_sdp.vhd
@@ -256,6 +256,9 @@ architecture rtl of olo_private_ram_sdp_nobe is
     -- Read registers
     signal RdPipe : Data_t(1 to RdLatency_g);
 
+    -- Synthesis attributes - Without this attribute the scoped constraint can't find this signal
+    attribute dont_touch of RdPipe : signal is true;
+
     -- Synthesis attributes - suppress shift register extraction
     attribute shreg_extract of RdPipe : signal is ShregExtract_SuppressExtraction_c;
 

--- a/src/base/vhdl/olo_base_ram_sdp.vhd
+++ b/src/base/vhdl/olo_base_ram_sdp.vhd
@@ -256,9 +256,6 @@ architecture rtl of olo_private_ram_sdp_nobe is
     -- Read registers
     signal RdPipe : Data_t(1 to RdLatency_g);
 
-    -- Synthesis attributes - Without this attribute the scoped constraint can't find this signal
-    attribute dont_touch of RdPipe : signal is true;
-
     -- Synthesis attributes - suppress shift register extraction
     attribute shreg_extract of RdPipe : signal is ShregExtract_SuppressExtraction_c;
 

--- a/src/intf/tcl/olo_intf_constraints_amd.tcl
+++ b/src/intf/tcl/olo_intf_constraints_amd.tcl
@@ -4,8 +4,8 @@ namespace eval olo_intf_constraints_amd {
 
 	puts "OLO LOAD read_xdc for intf"
 
-	read_xdc -quiet -ref olo_intf_sync $fileLoc/olo_intf_sync.tcl
-	read_xdc -quiet -ref olo_intf_spi_master $fileLoc/olo_intf_spi_master.tcl
+	read_xdc -quiet -ref olo_intf_sync $fileLoc/olo_intf_sync.tcl -unmanaged
+	read_xdc -quiet -ref olo_intf_spi_master $fileLoc/olo_intf_spi_master.tcl -unmanaged
 
 	set_property used_in_synthesis false [get_files $fileLoc/olo_intf_sync.tcl]
 	set_property used_in_synthesis false [get_files $fileLoc/olo_intf_spi_master.tcl]


### PR DESCRIPTION
@obruendl as mentioned in this issue https://github.com/open-logic/open-logic/issues/202, this scoped constraint mark a CDC path as un-timed when the RAM type is LUTRAM.

However before we merge this we need to address 3 topics:

**Topic 1**
As mentioned in the issue, I think this path is not safe if read and write operations to the same address are done, so **I would not add this scoped constraint and until that is cleared out.**

**Topic 2**
The scoped constraints are currently being added as "XDC" files and not TCL. The scoped constrained implemented in this pull request needs the file type to be TCL as it executes an if-statement.

<img width="521" height="717" alt="image" src="https://github.com/user-attachments/assets/e72501a9-b2cd-44e5-b684-e1b73cc0c337" />

In the past you were adding this as TCL, note how the icon is different:

<img width="1214" height="204" alt="image" src="https://github.com/user-attachments/assets/49a291af-9eb1-471a-a8a5-5b1aaa202c39" />

What do we need to do to add them as TCL?

**Topic 3**

I tried to force the Async FIFO to be implemented as BLOCKRAM so I could test my if-statement above:
```vhdl
    i_fifo : entity work.olo_base_fifo_async
    generic map(
        Width_g                         => fifo_din'length,
        Depth_g                         => 4096*4, -- LARGE
        AlmFullOn_g                     => false,
        AlmFullLevel_g                  => 0,
        AlmEmptyOn_g                    => false,
        AlmEmptyLevel_g                 => 0,
        RamStyle_g                      => "block", -- BLOCK!!!!
        RamBehavior_g                   => "RBW",
        ReadyRstState_g                 => '1',
        Optimization_g                  => "SPEED",
        SyncStages_g                    => 2
    )
```

However, Vivado refuses and still implements it as LUTRAM:

<img width="851" height="167" alt="image" src="https://github.com/user-attachments/assets/890ee446-6ee9-41b2-99a3-28becb7d29b7" />

In your synthesis/PAR tests, did you ever check if your ASYNC FIFO can be mapped to BRAMs?
