### PR TITLE
Set olo_base_cc_status port defaults according to documentation

### DIFF
--- a/src/base/vhdl/olo_base_cc_status.vhd
+++ b/src/base/vhdl/olo_base_cc_status.vhd
@@ -41,8 +41,8 @@ entity olo_base_cc_status is
         In_RstOut   : out   std_logic;
         In_Data     : in    std_logic_vector(Width_g - 1 downto 0);
         Out_Clk     : in    std_logic;
-        Out_RstIn   : in    std_logic;
-        Out_RstOut  : out   std_logic := '0';
+        Out_RstIn   : in    std_logic := '0';
+        Out_RstOut  : out   std_logic;
         Out_Data    : out   std_logic_vector(Width_g - 1 downto 0)
     );
 end entity;


### PR DESCRIPTION
While using olo_base_cc_status I noticed the port defaults are not as documented. Since documentation is the logical correct way, I corrected the code.