### PR TITLE
IMPROVEMENT: Switch linting script to Path module

### DIFF
--- a/lint/script/script.py
+++ b/lint/script/script.py
@@ -1,9 +1,10 @@
 import os
 import argparse
 import platform
+from pathlib import Path
 
 # Change directory to the script directory
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+os.chdir(Path(__file__).parent)
 
 # Detect arguments
 parser = argparse.ArgumentParser(description='Lint all VHDL files in the project')
@@ -19,7 +20,7 @@ DIR = '../..'
 NOT_LINTED = ["RbExample.vhd"] # Docmentation example, incomplete VHDL
 NOT_LINTED_DIR = ["../../3rdParty/"] # 3rd party libraries
 
-# Windows has a command lenght limit of 8192. We therefore chunk files
+# Windows has a command length limit of 8192. We therefore chunk files
 # into smaller pieces on Windows (not on linux to avoid speed penalty).
 # Size chosen: 8192 / 256 (max path length) = 32. USe 30 to leave some
 # characters for the rest of the command
@@ -31,57 +32,56 @@ def chunked_files(files):
     else:
         yield files
 
+def files_to_string(string, file_paths):
+    return string.join(str(path) for path in file_paths)
+
 def root_is_vc(root):
-    return root.endswith('test/tb') or root.endswith('test\\tb')
+    return root.name == 'tb' and root.parent.name == 'test'
 
 def find_normal_vhd_files(directory):
     vhd_files = []
-    for root, _, files in os.walk(directory):
+    
+    for file in directory.rglob('*.vhd'):
         # Skip directories that are not relevant (including subdirectories)
-        root_lin = root.replace('\\', '/')
-        if any(root_lin.startswith(not_linted) for not_linted in NOT_LINTED_DIR):
+        if any(file.resolve().is_relative_to(Path(not_linted).resolve()) for not_linted in NOT_LINTED_DIR):
             continue
-
-        #Lint files
-        for file in files:
-            # Skip VC files
-            if root_is_vc(root):
-                continue
-            # Skip non VHD files
-            if not file.endswith('.vhd'):
-                continue
-            # Skip not linted files
-            if file in NOT_LINTED:
-                continue
-            #Append file
-            vhd_files.append(os.path.abspath(os.path.join(root, file)))
+            
+        # Skip VC files
+        if root_is_vc(file.parent):
+            continue
+            
+        # Skip not linted files
+        if file.name in NOT_LINTED:
+            continue
+            
+        #Append file
+        vhd_files.append(file.resolve())
     return vhd_files
 
 def find_vc_vhd_files(directory):
     vhd_files = []
-    for root, _, files in os.walk(directory):
-        for file in files:
-            # Only add VC files
-            if root_is_vc(root):
-                vhd_files.append(os.path.abspath(os.path.join(root, file)))
+    
+    for file in directory.rglob('*.vhd'):
+        # Only add VC files
+        if root_is_vc(file.parent):
+            vhd_files.append(file.resolve())
     return vhd_files
 
 # Configure output format
-otutput_format = "-of vsg"
+output_format = "-of vsg"
 if args.syntastic:
-    otutput_format = "-of syntastic"
-
+    output_format = "-of syntastic"
 
 # Get the list of .vhd files
-vhd_files_list = find_normal_vhd_files(DIR)
-vc_files_list = find_vc_vhd_files(DIR)
+vhd_files_list = find_normal_vhd_files(Path(DIR))
+vc_files_list = find_vc_vhd_files(Path(DIR))
 
 # Print the list of files found
 print("Normal VHDL Files")
-print("\n".join(vhd_files_list))
+print(files_to_string("\n", vhd_files_list))
 print()
 print("VC VHDL Files")
-print("\n".join(vc_files_list))
+print(files_to_string("\n", vc_files_list))
 print()
 print("Start Linting")
 
@@ -91,13 +91,13 @@ error_occurred = False
 if args.debug:
     for file in vhd_files_list:
         print(f"Linting {file}: Normal Config")
-        result = os.system(f'vsg -c ../config/vsg_config.yml -f {file} {otutput_format}')
+        result = os.system(f'vsg -c ../config/vsg_config.yml -f {file} {output_format}')
         if result != 0:
             raise Exception(f"Error: Linting of {file} failed - check report")
 else:
     for chunk in chunked_files(vhd_files_list):
-        all_files = " ".join(chunk)
-        result = os.system(f'vsg -c ../config/vsg_config.yml -f {all_files} --junit ../report/vsg_normal_vhdl.xml --all_phases {otutput_format}')
+        all_files = files_to_string(" ", chunk)
+        result = os.system(f'vsg -c ../config/vsg_config.yml -f {all_files} --junit ../report/vsg_normal_vhdl.xml --all_phases {output_format}')
         if result != 0:
             error_occurred = True
     
@@ -105,13 +105,13 @@ else:
 if args.debug:
     for file in vc_files_list:
         print(f"Linting {file}: VC Config")
-        result = os.system(f'vsg -c ../config/vsg_config.yml ../config/vsg_config_overlay_vc.yml -f {file} {otutput_format}')
+        result = os.system(f'vsg -c ../config/vsg_config.yml ../config/vsg_config_overlay_vc.yml -f {file} {output_format}')
         if result != 0:
             raise Exception(f"Error: Linting of {file} failed - check report")
 else:
     for chunk in chunked_files(vc_files_list):
-        all_files = " ".join(chunk)
-        result = os.system(f'vsg -c ../config/vsg_config.yml ../config/vsg_config_overlay_vc.yml -f {all_files} --junit ../report/vsg_vc_vhdl.xml --all_phases {otutput_format}')
+        all_files = files_to_string(" ", chunk)
+        result = os.system(f'vsg -c ../config/vsg_config.yml ../config/vsg_config_overlay_vc.yml -f {all_files} --junit ../report/vsg_vc_vhdl.xml --all_phases {output_format}')
         if result != 0:
             error_occurred = True
 
@@ -120,6 +120,5 @@ if error_occurred:
 
 # Print success message
 print("All VHDL files linted successfully")
-
 
 


### PR DESCRIPTION
As mentioned in #214, it would be a good idea to switch to pathlib to be more independent of the operating system. This PR implements this change.

In detail, the following changes are made:
- Change all functions to work with Path() objects.
- Removed special handling of Windows and Linux. The chunking is still required, though.
- Switched to `rglob `from pathlib instead of `os.walk()`
- Corrected spelling of `otutput_format` --> `output_format` and `lenght` --> `length`

I verified the changes under Windows 11 and Linux (WSL, Ubuntu 24.04).