### PR TITLE
IMPROVEMENT: Make initial value the same as reset value

### DIFF
--- a/src/base/vhdl/olo_base_cc_reset.vhd
+++ b/src/base/vhdl/olo_base_cc_reset.vhd
@@ -52,12 +52,12 @@ architecture struct of olo_base_cc_reset is
 
     -- Domain A signals
     signal RstALatch  : std_logic                    := '1';
-    signal RstRqstB2A : std_logic_vector(2 downto 0) := (others => '0');
+    signal RstRqstB2A : std_logic_vector(2 downto 0) := (others => '1');
     signal RstAckB2A  : std_logic;
 
     -- Domain B signals
     signal RstBLatch  : std_logic                    := '1';
-    signal RstRqstA2B : std_logic_vector(2 downto 0) := (others => '0');
+    signal RstRqstA2B : std_logic_vector(2 downto 0) := (others => '1');
     signal RstAckA2B  : std_logic;
 
     -- Synthesis attributes - suppress shift register extraction


### PR DESCRIPTION
Follow up from #241.

This PR changes the initial value on the `RstRqstB2A` and `RstRqstA2B` in the block `olo_base_cc_reset` to match their reset value.

This is mainly done, as altera implements, depending on the used device, the inital value with asynchronous signals. In this specific block, the asynchronous rest is however already used and sets these FF to a different value than their initial value which results in critical warnings.

I used the arria10 device, which resulted in this behaviour.

For the sake of completness, I also checked the other `*_base_*` blocks. The only other found block with asynchronous resets was `olo_base_reset_gen` which has the initial values the same as the reset values.