### PR TITLE
BUGFIX: update port name in doc for `olo_intf_debounce` to one used in VHDL

### DIFF
--- a/doc/intf/olo_intf_debounce.md
+++ b/doc/intf/olo_intf_debounce.md
@@ -47,7 +47,7 @@ Below figure provides an example waveform for both modes of operation.
 | Clk       | in     | 1         | -       | Clock                                                        |
 | Rst       | in     | 1         | '0'     | Reset input (high-active, synchronous to _Clk_)<br />For synchronizers the reset is normally not required. |
 | DataAsync | in     | _Width_g_ | -       | Vector of independent input bits (asynchronous external input). |
-| DataSync  | out    | _Width_g_ | N/A     | Vector of synchronized and debounced output bits (synchronous to _Clk_) |
+| DataOut   | out    | _Width_g_ | N/A     | Vector of synchronized and debounced output bits (synchronous to _Clk_) |
 
 ## Architecture
 


### PR DESCRIPTION
The name of the output port in the docs for `olo_intf_debounce` did not match the one used in the VHDL description.
`DataSync -> DataOut`