### PR TITLE
BUGFIX: Fix olo_fix_cordic_rot IntXyGmt_g=AUTO case 

### DIFF
--- a/src/fix/vhdl/olo_fix_cordic_rot.vhd
+++ b/src/fix/vhdl/olo_fix_cordic_rot.vhd
@@ -72,7 +72,7 @@ architecture rtl of olo_fix_cordic_rot is
     constant InAngFmt_c        : FixFormat_t   := cl_fix_format_from_string(InAngFmt_g);
     constant OutFmt_c          : FixFormat_t   := cl_fix_format_from_string(OutFmt_g);
     constant IntXyFmt_c        : FixFormat_t   := choose(compareNoCase(IntXyFmt_g, "AUTO"),
-                                                         (1, InMagFmt_c.I + 1, InMagFmt_c.F + 3),
+                                                         (1, InMagFmt_c.I + 1, OutFmt_c.F + 3),
                                                          fixFmtFromStringTolerant(IntXyFmt_g));
     constant IntAngFmt_c       : FixFormat_t   := choose(compareNoCase(IntAngFmt_g, "AUTO"),
                                                          (1, -2, InAngFmt_c.F + 3),


### PR DESCRIPTION
format did not match python

VHDL is updated because the internal format only must represent the bits required to generate the output in sufficient precision.

reported by [abdomit](https://github.com/abdomit)[abdomit](https://github.com/abdomit)

refs #287 