### PR TITLE
Fix/tcl multi clock bufgmux period

### DIFF
--- a/src/base/tcl/olo_base_cc_bits.tcl
+++ b/src/base/tcl/olo_base_cc_bits.tcl
@@ -10,7 +10,7 @@
 set launch_clk [get_clocks -of_objects [get_cell RegIn*]]
 set latch_clk [get_clocks -of_objects [get_cell Reg0*]]
 
-set period [expr min([get_property PERIOD $launch_clk], [get_property PERIOD $latch_clk])]
+set period [expr [get_property -min PERIOD [concat $launch_clk $latch_clk]]]
 
 set_max_delay -from $launch_clk -to [get_cell Reg0*] -datapath_only $period
 set_bus_skew -from [get_cell RegIn*] -to [get_cell Reg0*] $period

--- a/src/base/tcl/olo_base_cc_bits.tcl
+++ b/src/base/tcl/olo_base_cc_bits.tcl
@@ -10,7 +10,7 @@
 set launch_clk [get_clocks -of_objects [get_cell RegIn*]]
 set latch_clk [get_clocks -of_objects [get_cell Reg0*]]
 
-set period [expr [get_property -min PERIOD [concat $launch_clk $latch_clk]]]
+set period [get_property -min PERIOD [concat $launch_clk $latch_clk]]
 
 set_max_delay -from $launch_clk -to [get_cell Reg0*] -datapath_only $period
 set_bus_skew -from [get_cell RegIn*] -to [get_cell Reg0*] $period

--- a/src/base/tcl/olo_base_cc_reset.tcl
+++ b/src/base/tcl/olo_base_cc_reset.tcl
@@ -10,7 +10,7 @@
 set launch_clk [get_clocks -of_objects [get_cell RstRqstB2A*]]
 set latch_clk [get_clocks -of_objects [get_cell RstRqstA2B*]]
 
-set period [expr [get_property -min PERIOD [concat $launch_clk $latch_clk]]]
+set period [get_property -min PERIOD [concat $launch_clk $latch_clk]]
 
 set_max_delay -from $launch_clk -to [get_cell RstRqst*] -datapath_only $period
 set_max_delay -from $latch_clk -to [get_cell RstRqst*] -datapath_only $period

--- a/src/base/tcl/olo_base_cc_reset.tcl
+++ b/src/base/tcl/olo_base_cc_reset.tcl
@@ -7,12 +7,10 @@
 # Load in vivado using "read_xdc -ref olo_base_cc_reset <path>/olo_base_cc_reset.tcl"
 
 #Get clocks based on cells, not ports because get_ports does not work reliable in scoped constraints
-set launch_clk [get_clocks -of_objects [get_cell RstRqstB2A*]] 
+set launch_clk [get_clocks -of_objects [get_cell RstRqstB2A*]]
 set latch_clk [get_clocks -of_objects [get_cell RstRqstA2B*]]
 
-set period [expr min([get_property PERIOD $launch_clk], [get_property PERIOD $latch_clk])]
+set period [expr [get_property -min PERIOD [concat $launch_clk $latch_clk]]]
 
 set_max_delay -from $launch_clk -to [get_cell RstRqst*] -datapath_only $period
 set_max_delay -from $latch_clk -to [get_cell RstRqst*] -datapath_only $period
-
-

--- a/src/base/tcl/olo_base_cc_simple.tcl
+++ b/src/base/tcl/olo_base_cc_simple.tcl
@@ -10,9 +10,7 @@
 set launch_clk [get_clocks -of_objects [get_cell DataLatchIn*]]
 set latch_clk [get_clocks -of_objects [get_cell Out_Data_Sig*]]
 
-set period [expr min([get_property PERIOD $launch_clk], [get_property PERIOD $latch_clk])]
-
+set period [expr [get_property -min PERIOD [concat $launch_clk $latch_clk]]]
 
 set_max_delay -from $launch_clk -to [get_cell Out_Data_Sig*] -datapath_only $period
 set_bus_skew -from [get_cell DataLatchIn*] -to [get_cell Out_Data_Sig*] $period
-

--- a/src/base/tcl/olo_base_cc_simple.tcl
+++ b/src/base/tcl/olo_base_cc_simple.tcl
@@ -10,7 +10,7 @@
 set launch_clk [get_clocks -of_objects [get_cell DataLatchIn*]]
 set latch_clk [get_clocks -of_objects [get_cell Out_Data_Sig*]]
 
-set period [expr [get_property -min PERIOD [concat $launch_clk $latch_clk]]]
+set period [get_property -min PERIOD [concat $launch_clk $latch_clk]]
 
 set_max_delay -from $launch_clk -to [get_cell Out_Data_Sig*] -datapath_only $period
 set_bus_skew -from [get_cell DataLatchIn*] -to [get_cell Out_Data_Sig*] $period

--- a/src/base/tcl/olo_base_ram_sdp.tcl
+++ b/src/base/tcl/olo_base_ram_sdp.tcl
@@ -22,7 +22,7 @@ if {[llength $mem_cells] > 0} {
       set launch_clk [get_clocks -of_objects [get_cell -hierarchical g_async.Mem_v*]]
       set latch_clk [get_clocks -of_objects [get_cell -hierarchical g_async.RdPipe_reg[1][*]]]
 
-      set period [get_property -min PERIOD [get_clocks "$launch_clk $latch_clk"]]
+      set period [get_property -min PERIOD [concat $launch_clk $latch_clk]]
 
       set_max_delay -from $launch_clk -to [get_cell -hierarchical g_async.RdPipe_reg[1][*]] -datapath_only $period
 

--- a/src/base/tcl/olo_base_reset_gen.tcl
+++ b/src/base/tcl/olo_base_reset_gen.tcl
@@ -10,5 +10,5 @@
 set_false_path -to [get_cell RstSyncChain*]
 
 #  Constrain input to synchronizer in case of synchronous assertion
-set period [get_property PERIOD [get_clocks -of_objects [get_cells *DsSync*]]]
-set_max_delay -from [get_cell RstSyncChain*] -to [get_cell *DsSync*] -datapath_only $period 
+set period [get_property -min PERIOD [get_clocks -of_objects [get_cells *DsSync*]]]
+set_max_delay -from [get_cell RstSyncChain*] -to [get_cell *DsSync*] -datapath_only $period

--- a/src/intf/tcl/olo_intf_spi_master.tcl
+++ b/src/intf/tcl/olo_intf_spi_master.tcl
@@ -9,7 +9,7 @@
 # The MISO signal is synchronized through SCLK anyways. Constraints are given to
 # make sure it arrives within one clock and to not hassle with timing errors
 # which do not exist in reality
- 
+
 #Get MISO port
 set in_ports [get_ports -scoped_to_current_instance -prop_thru_buffers -of_objects [get_nets *SpiMiso_i*]]
 #Get clock (busy is not involved, any FF will do)
@@ -19,6 +19,4 @@ set latch_clk [get_clocks -of_objects [get_cells *Busy*]]
 set_input_delay -clock $latch_clk -add_delay -max 0.0 $in_ports
 
 #Min delay does not play any role. Set to one clock period to avoid needless hold-warnings.
-set_input_delay -clock $latch_clk -add_delay -min [get_property PERIOD $latch_clk] $in_ports
-
-
+set_input_delay -clock $latch_clk -add_delay -min [get_property -min PERIOD $latch_clk] $in_ports

--- a/src/intf/tcl/olo_intf_sync.tcl
+++ b/src/intf/tcl/olo_intf_sync.tcl
@@ -5,7 +5,7 @@
 
 # Scoped constraints for olo_intf_sync
 # Load in vivado using "read_xdc -ref olo_intf_sync <path>/olo_intf_sync.tcl"
- 
+
 #Get D-Pins of Input FFs
 set in_ffs [get_pins -of_objects [get_cells *Reg0*] -filter {REF_PIN_NAME == D}]
 #Get Ports connected to those nets
@@ -14,7 +14,7 @@ set in_ports [get_ports -scoped_to_current_instance -prop_thru_buffers -of_objec
 set latch_clk [get_clocks -of_objects [get_cells *Reg0*]]
 
 #Set max delay to ensure delay Port->FF is less than one clock period
-set_max_delay -datapath_only [get_property PERIOD $latch_clk] -from $in_ports
+set_max_delay -datapath_only [get_property -min PERIOD $latch_clk] -from $in_ports
 
 #Make sure the first FF is not placed in the IOB. This ensures both FFs are placed in the same slice.
 set_property IOB FALSE [get_cells *Reg0*]


### PR DESCRIPTION
As described in #306 the TCL scripts do not cover the possibility of cells being driven by more then one clock. This might happen if the clock originaltes from a BUFGMUX for example where Vivado uses more than one clock for the timing analysis. 