### PR TITLE
FIX: Update VHDL assertion messages and comment typo

### DIFF
--- a/src/fix/vhdl/olo_fix_bin_div.vhd
+++ b/src/fix/vhdl/olo_fix_bin_div.vhd
@@ -80,10 +80,10 @@ architecture rtl of olo_fix_bin_div is
 begin
 
     -----------------------------------------------------------------------------------------------
-    -- Addertions
+    -- Assertions
     -----------------------------------------------------------------------------------------------
     assert compareNoCase(Mode_g, "PIPELINED") or compareNoCase(Mode_g, "SERIAL")
-        report "###ERROR###: olo_fix_cordic_rot: Mode_g must be PIPELINED or SERIAL"
+        report "###ERROR###: olo_fix_bin_div: Mode_g must be PIPELINED or SERIAL"
         severity error;
 
     -----------------------------------------------------------------------------------------------

--- a/src/fix/vhdl/olo_fix_cordic_vect.vhd
+++ b/src/fix/vhdl/olo_fix_cordic_vect.vhd
@@ -220,7 +220,7 @@ begin
         report "###ERROR###: olo_fix_cordic_vect: IntAngFmt_g must be (1,-1,x)"
         severity error;
     assert compareNoCase(Mode_g, "PIPELINED") or compareNoCase(Mode_g, "SERIAL")
-        report "###ERROR###: olo_fix_cordic_rot: Mode_g must be PIPELINED or SERIAL"
+        report "###ERROR###: olo_fix_cordic_vect: Mode_g must be PIPELINED or SERIAL"
         severity error;
 
     -- *** Pipelined Implementation ***


### PR DESCRIPTION
While testing the `olo_fix_bin_div` block, I stumbled upon an incorrect message in the included assertion. I then searched for other "wrong" assertions and found another one in the `olo_fix_cordic_vect` block.

- Corrected "Addertions" to "Assertions" in a comment.
- Replaced incorrect component names in error messages for `olo_fix_bin_div` and `olo_fix_cordic_vect` modules.