### PR TITLE
CLEANUP: Fix 6h CI time-limit

### DIFF
--- a/.github/workflows/synthesis.yml
+++ b/.github/workflows/synthesis.yml
@@ -42,6 +42,7 @@ jobs:
   # Synthesis Test
   synthesis:
     runs-on: [self-hosted, aws]
+    timeout-minutes: 720
     needs: start-instance
     steps:
       # Checkout the repository


### PR DESCRIPTION
synthesis runs longer than 6h