### PR TITLE
Update olo_base_crc_append component to support CRCs wider than the bus width

### DIFF
--- a/sim/test_configs/olo_base.py
+++ b/sim/test_configs/olo_base.py
@@ -335,6 +335,14 @@ def add_configs(olo_tb):
     for DataWidth, CrcWidth in [(8, 8), (16, 8), (16, 16)]:
         named_config(tb, {'CrcWidth_g': CrcWidth, 'DataWidth_g': DataWidth})
 
+    ### olo_base_crc_append_be ###
+    crc_append_be_tb = 'olo_base_crc_append_be_tb'
+    tb = olo_tb.test_bench(crc_append_be_tb)  
+    CrcNames = ["CRC-8/DVB-S2", "CRC-16/DECT-X", "CRC-32/ISO-HDLC"]
+    for RandomStall in [True, False]:
+        for Crc in CrcNames:
+            named_config(tb, {'CrcName_g': Crc,'RandomStall_g' : RandomStall})
+
     ### olo_base_crc_check ###
     crc_check_tb = 'olo_base_crc_check_tb'
     tb = olo_tb.test_bench(crc_check_tb)  

--- a/src/base/vhdl/olo_base_crc_append.vhd
+++ b/src/base/vhdl/olo_base_crc_append.vhd
@@ -45,15 +45,17 @@ entity olo_base_crc_append is
         Clk              : in    std_logic;
         Rst              : in    std_logic;
         -- Input
-        In_Data          : in    std_logic_vector(DataWidth_g-1 downto 0);
-        In_Valid         : in    std_logic := '1';
         In_Ready         : out   std_logic;
+        In_Valid         : in    std_logic := '1';
         In_Last          : in    std_logic;
+        In_Be            : in    std_logic_vector(DataWidth_g/8-1 downto 0) := (others => '1');
+        In_Data          : in    std_logic_vector(DataWidth_g-1 downto 0);
         -- Output
-        Out_Data         : out   std_logic_vector(DataWidth_g-1 downto 0);
-        Out_Valid        : out   std_logic;
         Out_Ready        : in    std_logic := '1';
-        Out_Last         : out   std_logic
+        Out_Valid        : out   std_logic;
+        Out_Last         : out   std_logic;
+        Out_Be           : out   std_logic_vector(DataWidth_g/8 - 1 downto 0);
+        Out_Data         : out   std_logic_vector(DataWidth_g-1 downto 0)
     );
 end entity;
 
@@ -66,70 +68,219 @@ architecture rtl of olo_base_crc_append is
     -- *** Constants ***
     constant EntityName_c : string := "olo_base_crc_append";
 
+    constant CrcBytes_c : natural := CrcPolynomial_g'length/8;
+    constant BeWidth_c  : natural := DataWidth_g/8;
+    -- data + be + last
+    constant ConcatWidth_c : natural := DataWidth_g + BeWidth_c + 1;
+
     -- *** Types ***
     type State_t is (Data_s, Crc_s);
 
     -- *** Two Process Method ***
     type TwoProcess_r is record
-        State : State_t;
+        CrcByteCnt : natural;
+        State      : State_t;
     end record;
 
-    signal r, r_next : TwoProcess_r;
+    signal r      : TwoProcess_r;
+    signal r_next : TwoProcess_r;
 
     -- *** Instantiation Signals ***
+    signal In_Concat : std_logic_vector(ConcatWidth_c-1 downto 0);
+
     signal Crc_Valid : std_logic;
     signal Crc_Ready : std_logic;
     signal Crc_Crc   : std_logic_vector(CrcPolynomial_g'length-1 downto 0);
-    signal Pl_Valid  : std_logic;
-    signal Pl_Data   : std_logic_vector(DataWidth_g-1 downto 0);
-    signal Pl_Last   : std_logic;
-    signal Pl_Ready  : std_logic;
-    signal In_Beat   : std_logic;
+
+    signal PlIn_Valid  : std_logic;
+    signal PlIn_Last   : std_logic;
+    signal PlIn_Be     : std_logic_vector(BeWidth_c-1 downto 0);
+    signal PlIn_Data   : std_logic_vector(DataWidth_g-1 downto 0);
+    signal PlIn_Concat : std_logic_vector(ConcatWidth_c-1 downto 0);
+
+    signal Fsm_Ready  : std_logic;
+    signal Fsm_Valid  : std_logic;
+    signal Fsm_Last   : std_logic;
+    signal Fsm_Be     : std_logic_vector(BeWidth_c-1 downto 0);
+    signal Fsm_Data   : std_logic_vector(DataWidth_g-1 downto 0);
+    signal Fsm_Concat : std_logic_vector(ConcatWidth_c-1 downto 0);
+
+    signal PlOut_Valid  : std_logic;
+    signal PlOut_Last   : std_logic;
+    signal PlOut_Be     : std_logic_vector(BeWidth_c-1 downto 0);
+    signal PlOut_Data   : std_logic_vector(DataWidth_g-1 downto 0);
+    signal PlOut_Concat : std_logic_vector(ConcatWidth_c-1 downto 0);
 
 begin
 
     -- *** Assertions ***
-    assert CrcPolynomial_g'length <= DataWidth_g
-        report errorMessage(EntityName_c, "Polynomial_g must be smaller or equal width than DataWidth_g")
-        severity error;
+    -- TODO: Think about edge cases. What if CRC width is not multiple of 8 bits?
+
+    --  assert CrcPolynomial_g'length <= DataWidth_g
+    --      report errorMessage(EntityName_c, "Polynomial_g must be smaller or equal width than DataWidth_g")
+    --      severity error;
 
     -- *** Combinatorial Process ***
     p_comb : process (all) is
         variable v : TwoProcess_r;
+
+        -- Helper Variables
+        variable NumBe_v             : natural;
+        variable NumBeWithCrc_v      : natural;
+        variable CrcBytesRemaining_v : natural;
     begin
         -- *** Hold Variables Stable ***
         v := r;
 
         -- *** FSM ***
-        In_Ready  <= '0';
+        Fsm_Valid <= '0';
+        Fsm_Last  <= 'U';
+        Fsm_Be    <= (others => 'U');
+        Fsm_Data  <= (others => 'U');
+
         Crc_Ready <= '0';
-        Pl_Data   <= (others => 'X');
-        Pl_Valid  <= '0';
-        Pl_Last   <= '0';
-        In_Beat   <= '0';
 
         case r.State is
+            --------------------------------------------------------------------
             when Data_s =>
-                Pl_Data  <= In_Data;
-                Pl_Valid <= In_Valid;
-                In_Ready <= Pl_Ready;
-                In_Beat  <= In_Valid and Pl_Ready;
+                -- Reset CRC byte counter.
+                -- Normally, this counter is reset when the complete CRC has been 
+                -- appended to the stream. 
+                -- This redundant reset is kept as a safeguard in case the counter 
+                -- was not reset at the expected point.
+                v.CrcByteCnt := 0;
 
-                if In_Valid = '1' and Pl_Ready = '1' and In_Last = '1' then
-                    v.State := Crc_s;
+                if (PlIn_Valid = '1' and Fsm_Ready = '1') then
+
+                    -- Possible cases:
+                    --  1) Not the last data-beat
+                    --  2) Last data-beat
+
+                    -- 1) Not the last data-beat
+                    if (PlIn_Last = '0') then
+
+                        Fsm_Valid <= '1';
+                        Fsm_Last  <= '0';
+                        Fsm_Be    <= PlIn_Be;
+                        Fsm_Data  <= PlIn_Data;
+
+                    -- 2) Last data-beat
+                    elsif (PlIn_Last = '1') then
+                        
+                        -- Possible cases:
+                        -- 2.1) Last data-beat is fully filled with data
+                        -- 2.2) Last data-beat is paritally filled with data
+
+                        -- 2.1) Last data-beat is fully filled with data
+                        if (PlIn_Be = onesVector(BeWidth_c)) then
+                            
+                            Fsm_Valid <= '1';
+                            Fsm_Last  <= '0';
+                            Fsm_Be    <= PlIn_Be;
+                            Fsm_Data  <= PlIn_Data;
+
+                            v.State := Crc_s;
+
+                        -- 2.2) Last data-beat is paritally filled with data
+                        else
+
+                            -- Possible cases:
+                            -- 2.2.1) Entire CRC fits in the remaining space of the last data beat
+                            -- 2.2.2) CRC does not fit in the remaining space of the last data beat.
+                            --        Part of the CRC is combined with DATA in this beat,
+                            --        and the remaining CRC will be appended in subsequent data-beats
+
+                            -- Helper variables
+                            NumBe_v        := count(PlIn_Be, '1');
+                            NumBeWithCrc_v := count(PlIn_Be, '1') + CrcBytes_c;
+
+                            -- 2.2.1) Entire CRC fits in the remaining space of the last data beat
+                            if (CrcBytes_c <= count(PlIn_Be, '0')) then
+
+                                Fsm_Valid <= '1';
+                                Fsm_Last  <= '1';
+                                Fsm_Be    <= 
+                                    zerosVector(BeWidth_c - NumBeWithCrc_v) &
+                                    onesVector(NumBeWithCrc_v);
+                                Fsm_Data  <=
+                                    zerosVector((BeWidth_c - NumBeWithCrc_v)*8) &
+                                    Crc_Crc &
+                                    PlIn_Data(NumBe_v*8-1 downto 0);
+
+                                -- Reset CRC byte counter after the complete 
+                                -- CRC has been appended to the stream.
+                                v.CrcByteCnt := 0;
+
+                                -- Ready to calculate the CRC for the next packet.
+                                Crc_Ready <= '1';
+
+                            -- 2.2.2) CRC does not fit in the remaining space of the last data beat.
+                            --        Part of the CRC is combined with DATA in this beat,
+                            --        and the remaining CRC will be appended in subsequent data-beats
+                            else
+
+                                Fsm_Valid <= '1';
+                                Fsm_Last  <= '0';
+                                Fsm_Be    <= (others => '1');
+                                Fsm_Data  <= 
+                                    Crc_Crc(count(PlIn_Be, '0')*8-1 downto 0)&
+                                    PlIn_Data(NumBe_v*8-1 downto 0);
+
+                                v.CrcByteCnt := count(PlIn_Be, '0');
+                                v.State      := Crc_s;
+
+                            end if;
+                        end if;
+                    end if;
                 end if;
 
+            --------------------------------------------------------------------
             when Crc_s =>
-                Pl_Data                <= (others => '0');
-                Pl_Data(Crc_Crc'range) <= Crc_Crc;
-                Pl_Valid               <= Crc_Valid;
-                Pl_Last                <= '1';
-                Crc_Ready              <= Pl_Ready;
 
-                if Crc_Valid = '1' and Pl_Ready = '1' then
-                    v.State := Data_s;
+                Fsm_Valid <= '1';
+
+                -- Helper Variable
+                CrcBytesRemaining_v := CrcBytes_c - r.CrcByteCnt;
+
+                if (Fsm_Valid = '1' and Fsm_Ready = '1') then
+
+                    -- Possible cases:
+                    --   1) Not the last data beat. CRC bytes are not yet fully appended on the stream
+                    --   2) Last data beat. All CRC bytes are fully appended on the stream
+                        
+                    --   1) Not the last data beat. CRC bytes are not yet fully appended on the stream
+                    if (r.CrcByteCnt + BeWidth_c < CrcBytes_c) then
+
+                        Fsm_Last <= '0';
+                        Fsm_Be   <= (others => '1');
+                        Fsm_Data <= Crc_Crc((r.CrcByteCnt+BeWidth_c)*8-1 downto r.CrcByteCnt*8);
+
+                        v.CrcByteCnt := r.CrcByteCnt + BeWidth_c;
+
+                    --   2) Last data beat. All CRC bytes are fully appended on the stream
+                    else
+
+                        Fsm_Last <= '1';
+                        Fsm_Be   <=
+                            zerosVector(BeWidth_c - CrcBytesRemaining_v) &
+                            onesVector(CrcBytesRemaining_v);
+                        Fsm_Data <=
+                            zerosVector((BeWidth_c - CrcBytesRemaining_v)*8) &
+                            Crc_Crc(CrcBytes_c*8-1 downto r.CrcByteCnt*8);
+
+                        -- Reset CRC byte counter after the complete 
+                        -- CRC has been appended to the stream.
+                        v.CrcByteCnt := 0;
+
+                        -- Ready to calculate the CRC for the next packet.
+                        Crc_Ready <= '1';
+
+                        v.State := Data_s;
+
+                    end if;
                 end if;
 
+            --------------------------------------------------------------------
             -- coverage off
             when others => null; -- unreachable code
             -- coverage on
@@ -148,12 +299,17 @@ begin
 
             -- Reset
             if Rst = '1' then
-                r.State <= Data_s;
+                r.CrcByteCnt <= 0;
+                r.State      <= Data_s;
             end if;
         end if;
     end process;
 
     -- *** Instantiations ***
+
+    ----------------------------------------------------------------------------
+    -- CRC
+    ----------------------------------------------------------------------------
     i_crc : entity work.olo_base_crc
         generic map (
             DataWidth_g     => DataWidth_g,
@@ -165,45 +321,80 @@ begin
             XorOutput_g     => CrcXorOutput_g
         )
         port map (
-            Clk              => Clk,
-            Rst              => Rst,
-            In_Data          => In_Data,
-            In_Valid         => In_Beat,
-            In_Last          => In_Last,
-            Out_Crc          => Crc_Crc,
-            Out_Valid        => Crc_Valid,
-            Out_Ready        => Crc_Ready
+            Clk       => Clk,
+            Rst       => Rst,
+
+            In_Ready  => In_Ready,
+            In_Valid  => In_Valid,
+            In_Last   => In_Last,
+            In_Be     => In_Be,
+            In_Data   => In_Data,
+
+            Out_Ready => Crc_Ready,
+            Out_Valid => Crc_Valid,
+            Out_Crc   => Crc_Crc
         );
 
-    b_pl : block is
-        signal PlInData  : std_logic_vector(DataWidth_g downto 0);
-        signal PlOutData : std_logic_vector(DataWidth_g downto 0);
-    begin
-        -- Input Assembly
-        PlInData <= Pl_Last & Pl_Data;
+    ----------------------------------------------------------------------------
+    -- Input Pipeline Stage
+    --     Required to delay the stream by one clock cycle to allow 
+    --     the CRC component sufficient time to calculate the CRC.
+    ----------------------------------------------------------------------------
+    -- Input Assembly
+    In_Concat <= In_Last & In_Be & In_Data;
 
-        -- Instance
-        i_pl_out : entity work.olo_base_pl_stage
-            generic map (
-                Width_g     => DataWidth_g+1,
-                UseReady_g  => true,
-                Stages_g    => 1
-            )
-            port map (
-                Clk       => Clk,
-                Rst       => Rst,
-                In_Valid  => Pl_Valid,
-                In_Ready  => Pl_Ready,
-                In_Data   => PlInData,
-                Out_Valid => Out_Valid,
-                Out_Ready => Out_Ready,
-                Out_Data  => PlOutData
-            );
+    -- Instance
+    i_pl_in : entity work.olo_base_pl_stage
+        generic map (
+            Width_g     => ConcatWidth_c,
+            UseReady_g  => false,
+            Stages_g    => 1
+        )
+        port map (
+            Clk       => Clk,
+            Rst       => Rst,
 
-        -- Output Assembly
-        Out_Last <= PlOutData(DataWidth_g);
-        Out_Data <= PlOutData(DataWidth_g-1 downto 0);
+            In_Valid  => (In_Valid and In_Ready),
+            In_Data   => In_Concat,
 
-    end block;
+            Out_Valid => PlIn_Valid,
+            Out_Data  => PlIn_Concat
+        );
+
+    -- Output Assembly
+    PlIn_Last <= PlIn_Concat(ConcatWidth_c - 1);
+    PlIn_Be   <= PlIn_Concat(ConcatWidth_c-2 downto DataWidth_g);
+    PlIn_Data <= PlIn_Concat(DataWidth_g-1 downto 0);
+
+    ----------------------------------------------------------------------------
+    -- Output Pipeline Stage
+    ----------------------------------------------------------------------------
+    -- Input Assembly
+    Fsm_Concat <= Fsm_Last & Fsm_Be & Fsm_Data;
+
+    -- Instance
+    i_pl_out : entity work.olo_base_pl_stage
+        generic map (
+            Width_g     => ConcatWidth_c,
+            UseReady_g  => true,
+            Stages_g    => 1
+        )
+        port map (
+            Clk       => Clk,
+            Rst       => Rst,
+
+            In_Ready  => Fsm_Ready,
+            In_Valid  => Fsm_Valid,
+            In_Data   => Fsm_Concat,
+
+            Out_Ready => Out_Ready,
+            Out_Valid => Out_Valid,
+            Out_Data  => PlOut_Concat
+        );
+
+    -- Output Assembly
+    Out_Last <= PlOut_Concat(ConcatWidth_c-1);
+    Out_Be   <= PlOut_Concat(ConcatWidth_c-2 downto DataWidth_g);
+    Out_Data <= PlOut_Concat(DataWidth_g-1 downto 0);
 
 end architecture;

--- a/src/base/vhdl/olo_base_crc_append.vhd
+++ b/src/base/vhdl/olo_base_crc_append.vhd
@@ -92,6 +92,7 @@ architecture rtl of olo_base_crc_append is
     signal Crc_Ready : std_logic;
     signal Crc_Crc   : std_logic_vector(CrcPolynomial_g'length-1 downto 0);
 
+    signal PlIn_Ready  : std_logic;
     signal PlIn_Valid  : std_logic;
     signal PlIn_Last   : std_logic;
     signal PlIn_Be     : std_logic_vector(BeWidth_c-1 downto 0);
@@ -110,6 +111,10 @@ architecture rtl of olo_base_crc_append is
     signal PlOut_Be     : std_logic_vector(BeWidth_c-1 downto 0);
     signal PlOut_Data   : std_logic_vector(DataWidth_g-1 downto 0);
     signal PlOut_Concat : std_logic_vector(ConcatWidth_c-1 downto 0);
+
+    -- Internal connection signals
+    signal Conn_PlIn_Ready : std_logic;
+    signal Conn_Crc_Ready  : std_logic;
 
 begin
 
@@ -140,6 +145,8 @@ begin
 
         Crc_Ready <= '0';
 
+        PlIn_Ready <= '0';
+
         case r.State is
             --------------------------------------------------------------------
             when Data_s =>
@@ -151,6 +158,8 @@ begin
                 v.CrcByteCnt := 0;
 
                 if (PlIn_Valid = '1' and Fsm_Ready = '1') then
+
+                    PlIn_Ready <= '1';
 
                     -- Possible cases:
                     --  1) Not the last data-beat
@@ -310,6 +319,9 @@ begin
     ----------------------------------------------------------------------------
     -- CRC
     ----------------------------------------------------------------------------
+
+    In_Ready <= Conn_PlIn_Ready and Conn_Crc_Ready;
+
     i_crc : entity work.olo_base_crc
         generic map (
             DataWidth_g     => DataWidth_g,
@@ -324,8 +336,8 @@ begin
             Clk       => Clk,
             Rst       => Rst,
 
-            In_Ready  => In_Ready,
-            In_Valid  => In_Valid,
+            In_Ready  => Conn_Crc_Ready,
+            In_Valid  => In_Valid and In_Ready,
             In_Last   => In_Last,
             In_Be     => In_Be,
             In_Data   => In_Data,
@@ -347,22 +359,24 @@ begin
     i_pl_in : entity work.olo_base_pl_stage
         generic map (
             Width_g     => ConcatWidth_c,
-            UseReady_g  => false,
+            UseReady_g  => true,
             Stages_g    => 1
         )
         port map (
             Clk       => Clk,
             Rst       => Rst,
 
-            In_Valid  => (In_Valid and In_Ready),
+            In_Ready  => Conn_PlIn_Ready,
+            In_Valid  => In_Valid and Conn_Crc_Ready,
             In_Data   => In_Concat,
 
+            Out_Ready => PlIn_Ready,
             Out_Valid => PlIn_Valid,
             Out_Data  => PlIn_Concat
         );
 
     -- Output Assembly
-    PlIn_Last <= PlIn_Concat(ConcatWidth_c - 1);
+    PlIn_Last <= PlIn_Concat(ConcatWidth_c-1);
     PlIn_Be   <= PlIn_Concat(ConcatWidth_c-2 downto DataWidth_g);
     PlIn_Data <= PlIn_Concat(DataWidth_g-1 downto 0);
 

--- a/test/base/olo_base_crc_append/olo_base_crc_append_be_tb.vhd
+++ b/test/base/olo_base_crc_append/olo_base_crc_append_be_tb.vhd
@@ -1,0 +1,419 @@
+---------------------------------------------------------------------------------------------------
+-- Copyright (c) 2025 by Oliver Bruendler, Switzerland
+-- Authors: Oliver Bruendler
+---------------------------------------------------------------------------------------------------
+
+---------------------------------------------------------------------------------------------------
+-- Libraries
+---------------------------------------------------------------------------------------------------
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.math_real.all;
+
+library vunit_lib;
+context vunit_lib.vunit_context;
+context vunit_lib.com_context;
+context vunit_lib.vc_context;
+
+library olo;
+use olo.olo_base_pkg_math.all;
+use olo.olo_base_pkg_array.all;
+use olo.olo_base_pkg_logic.all;
+use olo.olo_base_pkg_string.all;
+
+---------------------------------------------------------------------------------------------------
+-- Entity
+---------------------------------------------------------------------------------------------------
+-- vunit: run_all_in_same_sim
+entity olo_base_crc_append_be_tb is
+    generic (
+        runner_cfg    : string;
+        CrcName_g     : string;
+        RandomStall_g : boolean
+
+    );
+end entity;
+
+architecture sim of olo_base_crc_append_be_tb is
+
+    ----------------------------------------------------------------------------
+    -- Constants
+    ----------------------------------------------------------------------------
+    constant DataWidth_c : natural := 16;
+    constant BeWidth_c   : natural := DataWidth_c/8;
+
+    constant ClkFrequency_c : real := 100.0e6;
+    constant ClkPeriod_c    : time := (1 sec)/ClkFrequency_c;
+
+    -- *** Verification Components ***
+    -- Slave VC
+    constant AxisSlave_c : axi_stream_slave_t := new_axi_stream_slave (
+            data_length  => DataWidth_c,
+            user_length  => BeWidth_c,
+            stall_config => new_stall_config(choose(RandomStall_g, 1.0, 0.0), 0, 5)
+        );
+
+    -- Master VC
+    constant AxisMaster_c : axi_stream_master_t := new_axi_stream_master (
+            data_length  => DataWidth_c,
+            user_length  => BeWidth_c,
+            stall_config => new_stall_config(choose(RandomStall_g, 1.0, 0.0), 0, 5)
+
+        );
+
+    ----------------------------------------------------------------------------
+    ----------------------------------------------------------------------------
+    -- TODO: Use CrcSettings_r from package
+    ----------------------------------------------------------------------------
+    ----------------------------------------------------------------------------
+
+    -----------------------------------------------------------------------------------------------
+    -- Types
+    -----------------------------------------------------------------------------------------------
+    type CrcName_t is (
+            Crc8_DvbS2,
+            Crc16_DectX,
+            Crc32_IsoHdlc
+        );
+
+    type CrcSettings_r is record
+        name          : CrcName_t;
+        polynomial    : std_logic_vector;
+        initialValue  : std_logic_vector;
+        bitOrder      : string;
+        bitFlipOutput : boolean;
+        xorOutput     : std_logic_vector;
+    end record;
+
+    -----------------------------------------------------------------------------------------------
+    -- Functions
+    -----------------------------------------------------------------------------------------------
+    -- Get crc algorithms from https://crccalc.com
+    function getCrcSettings (crcName : in string) return CrcSettings_r is
+    begin
+        if toUpper(crcName) = "CRC-8/DVB-S2" then
+            return CrcSettings_r'(
+                name          => Crc8_DvbS2,
+                polynomial    => x"D5",
+                initialValue  => x"00",
+                bitOrder      => "MSB_FIRST",
+                bitFlipOutput => false,
+                xorOutput     => x"00"
+            );
+        elsif toUpper(crcName) = "CRC-16/DECT-X" then
+            return CrcSettings_r'(
+                name          => Crc16_DectX,
+                polynomial    => x"0589",
+                initialValue  => x"0000",
+                bitOrder      => "MSB_FIRST",
+                bitFlipOutput => false,
+                xorOutput     => x"0000"
+            );
+        elsif toUpper(crcName) = "CRC-32/ISO-HDLC" then
+            return CrcSettings_r'(
+                name          => Crc32_IsoHdlc,
+                polynomial    => x"04C11DB7",
+                initialValue  => x"FFFFFFFF",
+                bitOrder      => "LSB_FIRST",
+                bitFlipOutput => true,
+                xorOutput     => x"FFFFFFFF"
+            );
+        else
+            assert false
+                report "Error: Unsupported crcName"
+                severity error;
+        end if;
+    end function;
+
+    constant CrcSettings_c : CrcSettings_r := getCrcSettings(CrcName_g);
+
+    -----------------------------------------------------------------------------------------------
+    -- Interface Signals
+    -----------------------------------------------------------------------------------------------
+    signal Clk : std_logic := '0';
+    signal Rst : std_logic;
+
+    signal In_Ready : std_logic;
+    signal In_Valid : std_logic;
+    signal In_Last  : std_logic;
+    signal In_Be    : std_logic_vector(DataWidth_c/8-1 downto 0);
+    signal In_Data  : std_logic_vector(DataWidth_c-1 downto 0);
+
+    signal Out_Ready : std_logic;
+    signal Out_Valid : std_logic;
+    signal Out_Last  : std_logic;
+    signal Out_Be    : std_logic_vector(DataWidth_c/8 - 1 downto 0);
+    signal Out_Data  : std_logic_vector(DataWidth_c-1 downto 0);
+
+begin
+
+    -----------------------------------------------------------------------------------------------
+    -- TB Control
+    -----------------------------------------------------------------------------------------------
+    test_runner_watchdog(runner, 1 ms);
+
+    p_control : process is
+        variable Ref_v : axi_stream_reference_t;
+    begin
+        test_runner_setup(runner, runner_cfg);
+
+        while test_suite loop
+
+            -- Reset
+            wait until rising_edge(Clk);
+            Rst <= '1';
+            wait for ClkPeriod_c;
+            wait until rising_edge(Clk);
+            Rst <= '0';
+            wait until rising_edge(Clk);
+
+            --------------------------------------------------------------------
+            --------------------------------------------------------------------
+            if run("Test") then
+                ----------------------------------------------------------------
+                -- Packet 1: 
+                --     Data:  0xCE
+                --     CRC8:  0xDA
+                --     CRC16: 0x9925
+                --     CRC32: 0xAEDE00CE
+                ----------------------------------------------------------------
+                push_axi_stream(net, AxisMaster_c, x"00CE", tuser => "01", tlast => '1');
+
+                if (CrcName_g = "CRC-8/DVB-S2") then
+                    check_axi_stream(net, AxisSlave_c, x"DACE", tuser => "11", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-16/DECT-X") then
+                    check_axi_stream(net, AxisSlave_c, x"25CE", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"0099", tuser => "01", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-32/ISO-HDLC") then
+                    check_axi_stream(net, AxisSlave_c, x"3ACE", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"DE00", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"00AE", tuser => "01", tlast => '1', blocking => false);
+
+                end if;
+
+                ----------------------------------------------------------------
+                -- Packet 2: 
+                --     Data:  0x5AAD
+                --     CRC8:  0x08
+                --     CRC16: 0x368F
+                --     CRC32: 0xA9EA7874
+                ----------------------------------------------------------------
+
+                push_axi_stream(net, AxisMaster_c, x"AD5A", tuser => "11", tlast => '1');
+
+                if (CrcName_g = "CRC-8/DVB-S2") then
+                    check_axi_stream(net, AxisSlave_c, x"AD5A", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"0008", tuser => "01", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-16/DECT-X") then
+                    check_axi_stream(net, AxisSlave_c, x"AD5A", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"368F", tuser => "11", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-32/ISO-HDLC") then
+                    check_axi_stream(net, AxisSlave_c, x"AD5A", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"7874", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"A9EA", tuser => "11", tlast => '1', blocking => false);
+
+                end if;
+
+                ----------------------------------------------------------------
+                -- Packet 3: 
+                --     Data:  0x5DBFB6
+                --     CRC8:  0x34
+                --     CRC16: 0xA1D8
+                --     CRC32: 0xDA7AC03F
+                ----------------------------------------------------------------
+
+                push_axi_stream(net, AxisMaster_c, x"BF5D", tuser => "11", tlast => '0');
+                push_axi_stream(net, AxisMaster_c, x"00B6", tuser => "01", tlast => '1');
+
+                if (CrcName_g = "CRC-8/DVB-S2") then
+                    check_axi_stream(net, AxisSlave_c, x"BF5D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"34B6", tuser => "11", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-16/DECT-X") then
+                    check_axi_stream(net, AxisSlave_c, x"BF5D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"D8B6", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"00A1", tuser => "01", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-32/ISO-HDLC") then
+                    check_axi_stream(net, AxisSlave_c, x"BF5D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"3FB6", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"7AC0", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"00DA", tuser => "01", tlast => '1', blocking => false);
+
+                end if;
+
+                ----------------------------------------------------------------
+                -- Packet 4: 
+                --     Data:  0x4CDD2DBC
+                --     CRC8:  0xF6
+                --     CRC16: 0x4CD0
+                --     CRC32: 0x972A3BB2
+                ----------------------------------------------------------------
+                push_axi_stream(net, AxisMaster_c, x"DD4C", tuser => "11", tlast => '0');
+                push_axi_stream(net, AxisMaster_c, x"BC2D", tuser => "11", tlast => '1');
+
+                if (CrcName_g = "CRC-8/DVB-S2") then
+                    check_axi_stream(net, AxisSlave_c, x"DD4C", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"BC2D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"00F6", tuser => "01", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-16/DECT-X") then
+                    check_axi_stream(net, AxisSlave_c, x"DD4C", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"BC2D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"4CD0", tuser => "11", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-32/ISO-HDLC") then
+                    check_axi_stream(net, AxisSlave_c, x"DD4C", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"BC2D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"3BB2", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"972A", tuser => "11", tlast => '1', blocking => false);
+
+                end if;
+
+                ----------------------------------------------------------------
+                -- TODO
+                -- Packet 5: 
+                --     Data:  0xA2293FC275
+                --     CRC8:  0xD1
+                --     CRC16: 0x424B
+                --     CRC32: 0xE76B498D
+                ----------------------------------------------------------------
+                push_axi_stream(net, AxisMaster_c, x"29A2", tuser => "11", tlast => '0');
+                push_axi_stream(net, AxisMaster_c, x"C23F", tuser => "11", tlast => '0');
+                push_axi_stream(net, AxisMaster_c, x"0075", tuser => "01", tlast => '1');
+
+                if (CrcName_g = "CRC-8/DVB-S2") then
+                    check_axi_stream(net, AxisSlave_c, x"29A2", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C23F", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"D175", tuser => "11", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-16/DECT-X") then
+                    check_axi_stream(net, AxisSlave_c, x"29A2", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C23F", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"4B75", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"0042", tuser => "01", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-32/ISO-HDLC") then
+                    check_axi_stream(net, AxisSlave_c, x"29A2", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C23F", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"8D75", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"6B49", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"00E7", tuser => "01", tlast => '1', blocking => false);
+
+                end if;
+
+                ----------------------------------------------------------------
+                -- TODO:
+                -- Packet 6: 
+                --     Data:  0x2A3401B421C8
+                --     CRC8:  0x44
+                --     CRC16: 0xC563
+                --     CRC32: 0x209FF77D
+                ----------------------------------------------------------------
+                push_axi_stream(net, AxisMaster_c, x"342A", tuser => "11", tlast => '0');
+                push_axi_stream(net, AxisMaster_c, x"B401", tuser => "11", tlast => '0');
+                push_axi_stream(net, AxisMaster_c, x"C821", tuser => "11", tlast => '1');
+
+                if (CrcName_g = "CRC-8/DVB-S2") then
+                    check_axi_stream(net, AxisSlave_c, x"342A", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"B401", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C821", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"0044", tuser => "01", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-16/DECT-X") then
+                    check_axi_stream(net, AxisSlave_c, x"342A", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"B401", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C821", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C563", tuser => "11", tlast => '1', blocking => false);
+
+                elsif (CrcName_g = "CRC-32/ISO-HDLC") then
+                    check_axi_stream(net, AxisSlave_c, x"342A", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"B401", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"C821", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"F77D", tuser => "11", tlast => '0', blocking => false);
+                    check_axi_stream(net, AxisSlave_c, x"209F", tuser => "11", tlast => '1', blocking => false);
+
+                end if;
+            end if;
+
+            wait for 1 us;
+            wait_until_idle(net, as_sync(AxisMaster_c));
+            wait_until_idle(net, as_sync(AxisSlave_c));
+
+        end loop;
+
+        -- TB done
+        test_runner_cleanup(runner);
+    end process;
+
+    -----------------------------------------------------------------------------------------------
+    -- Clock
+    -----------------------------------------------------------------------------------------------
+    Clk <= not Clk after 0.5 * ClkPeriod_c;
+
+    -----------------------------------------------------------------------------------------------
+    -- DUT
+    -----------------------------------------------------------------------------------------------
+    i_dut : entity olo.olo_base_crc_append
+        generic map (
+            DataWidth_g    => DataWidth_c,
+            CrcByteOrder_g => "LSB_FIRST",
+
+            CrcPolynomial_g    => CrcSettings_c.polynomial,
+            CrcInitialValue_g  => CrcSettings_c.initialValue,
+            CrcBitOrder_g      => CrcSettings_c.bitOrder,
+            CrcBitflipOutput_g => CrcSettings_c.bitFlipOutput,
+            CrcXorOutput_g     => CrcSettings_c.xorOutput
+        )
+        port map (
+            Clk => Clk,
+            Rst => Rst,
+
+            In_Ready => In_Ready,
+            In_Valid => In_Valid,
+            In_Last  => In_Last,
+            In_Be    => In_Be,
+            In_Data  => In_Data,
+
+            Out_Valid => Out_Valid,
+            Out_Ready => Out_Ready,
+            Out_Last  => Out_Last,
+            Out_Be    => Out_Be,
+            Out_Data  => Out_Data
+        );
+
+    -----------------------------------------------------------------------------------------------
+    -- Verification Components
+    -----------------------------------------------------------------------------------------------
+    vc_stimuli : entity vunit_lib.axi_stream_master
+        generic map (
+            Master => AxisMaster_c
+        )
+        port map (
+            AClk   => Clk,
+            TValid => In_Valid,
+            TReady => In_Ready,
+            TData  => In_Data,
+            TUser  => In_Be,
+            TLast  => In_Last
+        );
+
+    vc_response : entity vunit_lib.axi_stream_slave
+        generic map (
+            Slave => AxisSlave_c
+        )
+        port map (
+            AClk   => Clk,
+            TValid => Out_Valid,
+            TReady => Out_Ready,
+            TData  => Out_Data,
+            TUser  => Out_Be,
+            TLast  => Out_Last
+        );
+
+end architecture;


### PR DESCRIPTION
## Description

This pull request addresses one of the issues described in #239, specifically the limitation of the olo_base_crc_append component when the CRC width is greater than the bus width.

I have implemented most of the updated olo_base_crc_append component, but I’m struggling with the final part of the implementation.

@obruendl , could you take a look at the current implementation and provide some guidance on how to approach the remaining part?

## What I am struggling with

I added an input pipeline stage because the input stream needs to be delayed by one clock cycle, giving the CRC component enough time to calculate the CRC that will be appended to the stream.

Previously, this was not necessary because the last data beat never contained any part of the CRC. With the updated implementation, however, the last data beat can contain either the entire CRC or part of the calculated CRC.

The problem is that I now have two instances, i_crc and i_pl_in, that could potentially control the In_Ready signal. In the current implementation, i_crc controls In_Ready, while i_pl_in has no backpressure control. This can lead to data beats being lost if the Out_* interface experiences long gaps in the data stream, where neither Out_Valid nor Out_Ready is asserted.

On the other hand, if I give backpressure control to i_pl_in, the CRC append logic fails when two packets arrive back-to-back. The calculated CRC for the first packet can be lost before it is written to the output stream, while the CRC for the second packet is already being calculated.

